### PR TITLE
Add performance.now/timeOrigin

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -77,7 +77,7 @@ Global methods / properties:
 * globalThis.{{console}}
 * globalThis.{{crypto}}
 * globalThis.{{navigator}}.{{userAgent}}
-* globalThis.{{performance}}.{{now()}}
+* globalThis.{{performance}}.{{Performance/now()}}
 * globalThis.{{performance}}.{{timeOrigin}}
 * globalThis.{{queueMicrotask()}}
 * globalThis.{{setTimeout()}} / globalThis.{{clearTimeout()}}

--- a/index.bs
+++ b/index.bs
@@ -77,6 +77,8 @@ Global methods / properties:
 * globalThis.{{console}}
 * globalThis.{{crypto}}
 * globalThis.{{navigator}}.{{userAgent}}
+* globalThis.{{performance}}.{{now()}}
+* globalThis.{{performance}}.{{timeOrigin}}
 * globalThis.{{queueMicrotask()}}
 * globalThis.{{setTimeout()}} / globalThis.{{clearTimeout()}}
 * globalThis.{{setInterval()}} / globalThis.{{clearInterval()}}


### PR DESCRIPTION
`performance.now()` and `performance.timeOrigin` are beginning to show up in more and more ecosystem modules. It makes sense to include them in the minimal set.