### PR TITLE
Remove URLPattern from the minimal set

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -64,7 +64,6 @@ Interfaces:
 * {{TransformStream}}
 * {{TransformStreamDefaultController}}
 * {{URL}}
-* <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/urlpattern/#urlpattern-class">URLPattern</a></code>
 * {{URLSearchParams}}
 * {{WritableStream}}
 * {{WritableStreamDefaultController}}


### PR DESCRIPTION
while URLPattern is implemented across multiple runtimes it is still (a) not fully standardized and (b) not fully supported by all of the runtimes. We can add this back later once support is a bit more broad.