### PR TITLE
Add `fetch` to the minimum common API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -50,12 +50,34 @@ Interfaces:
 * {{Event}}
 * {{EventTarget}}
 * {{File}}
+* {{FormData}}
+
+    Issue: The {{FormData}} constructor optionally takes {{HTMLFormElement}} and {{HTMLElement}} as parameters.
+    TODO: Figure out what implementations without DOM support should do here.
+    Node.js and Deno throw if the first parameter is not `undefined` but ignore the second parameter.
+    Cloudflare Workers ignores all parameters.
+
+* {{Headers}}
+
+    Note: The WinterCG is working on a fork of the Fetch spec to better fulfill the needs of web-interoperable runtimes.
+    See <a href="https://fetch.spec.wintercg.org">https://fetch.spec.wintercg.org</a>.
+
 * {{ReadableByteStreamController}}
 * {{ReadableStream}}
 * {{ReadableStreamBYOBReader}}
 * {{ReadableStreamBYOBRequest}}
 * {{ReadableStreamDefaultController}}
 * {{ReadableStreamDefaultReader}}
+* {{Request}}
+
+    Note: The WinterCG is working on a fork of the Fetch spec to better fulfill the needs of web-interoperable runtimes.
+    See <a href="https://fetch.spec.wintercg.org">https://fetch.spec.wintercg.org</a>.
+
+* {{Response}}
+
+    Note: The WinterCG is working on a fork of the Fetch spec to better fulfill the needs of web-interoperable runtimes.
+    See <a href="https://fetch.spec.wintercg.org">https://fetch.spec.wintercg.org</a>.
+
 * {{SubtleCrypto}}
 * {{TextDecoder}}
 * {{TextDecoderStream}}
@@ -75,6 +97,11 @@ Global methods / properties:
 * globalThis.{{btoa()}}
 * globalThis.{{console}}
 * globalThis.{{crypto}}
+* globalThis.{{fetch()}}
+
+    Note: The WinterCG is working on a fork of the Fetch spec to better fulfill the needs of web-interoperable runtimes.
+    See <a href="https://fetch.spec.wintercg.org">https://fetch.spec.wintercg.org</a>.
+
 * globalThis.{{navigator}}.{{userAgent}}
 * globalThis.{{performance}}.{{Performance/now()}}
 * globalThis.{{performance}}.{{timeOrigin}}

--- a/index.bs
+++ b/index.bs
@@ -58,10 +58,6 @@ Interfaces:
     Cloudflare Workers ignores all parameters.
 
 * {{Headers}}
-
-    Note: The WinterCG is working on a fork of the Fetch spec to better fulfill the needs of web-interoperable runtimes.
-    See <a href="https://fetch.spec.wintercg.org">https://fetch.spec.wintercg.org</a>.
-
 * {{ReadableByteStreamController}}
 * {{ReadableStream}}
 * {{ReadableStreamBYOBReader}}
@@ -69,15 +65,7 @@ Interfaces:
 * {{ReadableStreamDefaultController}}
 * {{ReadableStreamDefaultReader}}
 * {{Request}}
-
-    Note: The WinterCG is working on a fork of the Fetch spec to better fulfill the needs of web-interoperable runtimes.
-    See <a href="https://fetch.spec.wintercg.org">https://fetch.spec.wintercg.org</a>.
-
 * {{Response}}
-
-    Note: The WinterCG is working on a fork of the Fetch spec to better fulfill the needs of web-interoperable runtimes.
-    See <a href="https://fetch.spec.wintercg.org">https://fetch.spec.wintercg.org</a>.
-
 * {{SubtleCrypto}}
 * {{TextDecoder}}
 * {{TextDecoderStream}}
@@ -98,10 +86,6 @@ Global methods / properties:
 * globalThis.{{console}}
 * globalThis.{{crypto}}
 * globalThis.{{fetch()}}
-
-    Note: The WinterCG is working on a fork of the Fetch spec to better fulfill the needs of web-interoperable runtimes.
-    See <a href="https://fetch.spec.wintercg.org">https://fetch.spec.wintercg.org</a>.
-
 * globalThis.{{navigator}}.{{userAgent}}
 * globalThis.{{performance}}.{{Performance/now()}}
 * globalThis.{{performance}}.{{timeOrigin}}
@@ -109,6 +93,8 @@ Global methods / properties:
 * globalThis.{{setTimeout()}} / globalThis.{{clearTimeout()}}
 * globalThis.{{setInterval()}} / globalThis.{{clearInterval()}}
 * globalThis.{{structuredClone()}}
+
+Note: This list includes APIs defined in [[FETCH]]. The WinterCG is currently working on a fork of this spec to better fulfill the needs of web-interoperable runtimes, and such runtimes should follow this fork instead. See <a href="https://fetch.spec.wintercg.org">https://fetch.spec.wintercg.org</a>.
 
 The Global Scope {#global-scope}
 ================================


### PR DESCRIPTION
Since non-browser WinterCG runtimes should use the WinterCG Fetch spec fork instead of the WHATWG spec, a note is added for every Fetch spec API linking to the fork.

Additionally, `Request` and `Response` require the `FormData` API, whose constructor optionally takes DOM elements. Different non-web runtimes behave differently here, so this PR adds an "Issue:" note marking it as a TODO.
