### PR TITLE
Disambiguate BackgroundFetch from Fetch Standard

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -90,7 +90,7 @@ Global methods / properties:
 * globalThis.{{btoa()}}
 * globalThis.{{console}}
 * globalThis.{{crypto}}
-* globalThis.{{fetch()}}
+* globalThis.{{backgroundFetch.fetch()}}
 * globalThis.{{navigator}}.{{userAgent}}
 * globalThis.{{performance}}.{{Performance/now()}}
 * globalThis.{{performance}}.{{timeOrigin}}


### PR DESCRIPTION
This Draft https://common-min-api.proposal.wintercg.org/ links to https://wicg.github.io/background-fetch/ not https://fetch.spec.whatwg.org/. Disambiguate.