### PR TITLE
[ci] Make deploys fail if the spec build fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build spec
         run: |
           mkdir -p out
-          curl --retry 2 https://api.csswg.org/bikeshed/ --output out/index.html --header "Accept: text/plain, text/html" -F die-on=fatal -F file=@"index.bs"
+          curl --retry 2 --fail https://api.csswg.org/bikeshed/ --output out/index.html --header "Accept: text/plain, text/html" -F die-on=fatal -F file=@"index.bs"
       - name: Upload to Deno Deploy
         uses: denoland/deployctl@v1
         with:


### PR DESCRIPTION
Our CI deploy action currently asks a server at api.csswg.org to build the spec, and then uses the response to that request as the build output. However, it does not check that the response's HTTP status code is successful, which can result in Internal Server Errors in that server being "propagated" to this spec, rather than resulting in a failed build. Similarly, fatal errors in building the spec (for invalid Bikeshed syntax, for example) would result in the list of errors being deployed.

This PR fixes that by allowing `curl` to fail for non-successful HTTP status codes.
