### PR TITLE
Fix typos and improve grammar

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
 
-All documentation, code and communication under this repository are covered by
+All documentation, code, and communication under this repository are covered by
 the
 [W3C Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/).

--- a/index.bs
+++ b/index.bs
@@ -33,7 +33,7 @@ While this term is intentionally broad to also encompass Web Browsers, the prima
 Common API Index {#index}
 =========================
 
-All <a>Web-interoperable Runtimes</a> conforming to this specification SHALL implement each of the following Web Platform APIs in accordance to their normative requirements except where modified here. Where any conforming runtime environment chooses (either by necessity or otherwise) to diverge from a normative requirement of the specification, clear explanations of such divergence MUST be made clearly and readily available in documentation.
+All <a>Web-interoperable Runtimes</a> conforming to this specification SHALL implement each of the following Web Platform APIs in accordance with their normative requirements except where modified here. Where any conforming runtime environment chooses (either by necessity or otherwise) to diverge from a normative requirement of the specification, clear explanations of such divergence MUST be made clearly and readily available in the documentation.
 
 Interfaces:
 
@@ -117,7 +117,7 @@ Requirements for navigator.userAgent
 ====================================
 
 The globalThis.{{navigator}}.{{userAgent}} property is provided such that application code can reliably identify the runtime within which it is running.
-The value of the property is a string conforming to the the <code class="idl"><a data-link-type="idl" href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3">`User-Agent`</a></code> construction in RFC 7231:
+The value of the property is a string conforming to the <code class="idl"><a data-link-type="idl" href="https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3">`User-Agent`</a></code> construction in RFC 7231:
 
 <pre>
   User-Agent      = product *( RWS ( product / comment ) )


### PR DESCRIPTION
Fix typos, fix/improve grammar, and replace wordy phrases with concise wording.