### PR TITLE
Fix `globalScope` -> `globalThis`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -109,7 +109,7 @@ Note: This list includes APIs defined in [[FETCH]]. The WinterCG is currently wo
 The Global Scope {#global-scope}
 ================================
 
-The exact type of the `globalScope` can vary across runtimes. Most Web Platform APIs are defined in terms that assume Web Browser environments that specifically expose types like {{Window}}, {{Worker}}, {{WorkerGlobalScope}}, and so forth. To simplify conformance, all Interfaces, methods, and properties defined by this specification MUST be exposed on the runtime's relevant global scope (e,g., `globalThis.crypto`, `globalThis.ReadableStream`, etc).
+The exact type of the global scope (`globalThis`) can vary across runtimes. Most Web Platform APIs are defined in terms that assume Web Browser environments that specifically expose types like {{Window}}, {{Worker}}, {{WorkerGlobalScope}}, and so forth. To simplify conformance, all Interfaces, methods, and properties defined by this specification MUST be exposed on the runtime's relevant global scope (e,g., `globalThis.crypto`, `globalThis.ReadableStream`, etc).
 
 With many runtimes, adding a new global-scoped property can introduce breaking changes when the new global conflicts with existing application code. Many Web Platform APIs define global properties using the `readonly` attribute. To avoid introducing breaking changes, runtimes conforming to this specification MAY choose to ignore the `readonly` attribute for properties being added to the global scope.
 


### PR DESCRIPTION
Should be `globalThis` not `globalScope`, just to clarify as it confused me for a sec :)

(Maybe mark as non-substantive as it ~is and W3C IPR is not easy doable for me right now :P)