### PR TITLE
Update spec metadata and deploy to match the "minimum common" name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,13 @@ jobs:
         run: |
           mkdir -p out
           curl --retry 2 --fail https://api.csswg.org/bikeshed/ --output out/index.html --header "Accept: text/plain, text/html" -F die-on=fatal -F file=@"index.bs"
+
+      - name: Copy file_server.ts
+        run: cp .github/workflows/file_server.ts out/.file_server.ts
+
       - name: Upload to Deno Deploy
         uses: denoland/deployctl@v1
         with:
           project: "proposal-common-min-api"
-          entrypoint: "https://deno.land/std@0.134.0/http/file_server.ts"
+          entrypoint: ".file_server.ts"
           root: out/

--- a/.github/workflows/file_server.ts
+++ b/.github/workflows/file_server.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env -S deno run --allow-net --allow-read
+
+import { serveDir } from "https://deno.land/std@0.134.0/http/file_server.ts";
+
+Deno.serve((req) => {
+    // If we're *.wintercg.org, 301-redirect to the new URL.
+    const url = new URL(req.url);
+    console.log(url);
+    if (url.hostname.endsWith(".wintercg.org")) {
+        url.hostname = "min-common-api.proposal.wintercg.org";
+        return Response.redirect(url, 301);
+    }
+
+    // Otherwise, serve the current dir
+    return serveDir(req, {
+        enableCors: true,
+        showDotfiles: false,
+    });
+});

--- a/index.bs
+++ b/index.bs
@@ -4,8 +4,8 @@ Shortname: common-web-platform-api
 Group: wintercg
 Status: w3c/CG-DRAFT
 Level: none
-URL: https://common-min-api.proposal.wintercg.org/
-Repository: https://github.com/wintercg/proposal-common-minimum-api
+URL: https://min-common-api.proposal.wintercg.org/
+Repository: https://github.com/wintercg/proposal-minimum-common-api
 Editor: James M Snell, Cloudflare https://cloudflare.com/, jsnell@cloudflare.com
 Abstract: Minimum Common Web Platform API for Non-Browser ECMAScript-based runtimes.
 Markup Shorthands: markdown yes


### PR DESCRIPTION
This PR updates the URL and repo of the Minimum Common API in the spec's metadata to reflect the new locations (with the "minimum common" order, rather than "common minimum"). It also updates the deploy so that the old URL redirects to the new one.

----

Do not merge until the repo has been renamed and the new URL points to the right place.